### PR TITLE
refactor: rename website title to 'Vrdndi' and remove redundant UI text

### DIFF
--- a/src/web/website_frontend.py
+++ b/src/web/website_frontend.py
@@ -95,7 +95,6 @@ class UpdateWebsitePage:
         
         
         with self.video_play_container:
-            ui.label('playing').classes('text-h4 text-center')
 
             #video_frame=f'''<iframe width="1120" height="630" src="https://www.youtube.com/embed/{videoid}" frameborder="0" allowfullscreen></iframe>'''
 


### PR DESCRIPTION
## Overview
Renamed the website and removed the text "playing" in video page

## Key Changes
- Updated website title in the main page from `personal_feed` (old project name)  to `vrdndi`
- Removed text "playing" in video page