### PR TITLE
refactor: move table initialization to class initializer

### DIFF
--- a/src/db/database.py
+++ b/src/db/database.py
@@ -39,6 +39,11 @@ class VrdndiDatabase:
 
         self.engine=sqlalchemy.create_engine(f'sqlite:///{self.dbpath}')
 
+        self._initial_registry_table()
+        self._initial_streamlit_schema()
+        self._initial_video_table()
+        
+
 
     def _initial_registry_table(self) ->None:
         '''initial regisry table before saving data intot it'''
@@ -57,7 +62,6 @@ class VrdndiDatabase:
         '''save a key value pair in registry table in the database'''
 
         with sq.connect(self.dbpath) as conn:
-            self._initial_registry_table()
 
             conn.execute(
                 "INSERT OR REPLACE INTO registry (name, value) VALUES (?,?)",
@@ -67,7 +71,6 @@ class VrdndiDatabase:
     def _get_registry_value(self,key:str) ->int:
         with sq.connect(self.dbpath) as conn:
 
-            self._initial_registry_table()
 
             cursor=conn.execute("SELECT value FROM registry WHERE name = ?",(key,))
 
@@ -318,7 +321,6 @@ class VrdndiDatabase:
         '''Save the streamlit labeled data to database'''
         pprint.pprint(data)
 
-        self._initial_streamlit_schema()
 
 
         data.to_sql('streamlit_data',con=self.engine,if_exists='append',index=False,method=self._insert_if_not_exits)
@@ -331,7 +333,6 @@ class VrdndiDatabase:
     def update_streamlit_index(self,index:int) ->None:
         '''Save the index of last datapoint into database'''
 
-        self._initial_registry_table()
 
         self._set_registry_value('streamlit_index',index)
 


### PR DESCRIPTION
## Overview
Moved the initialization table function to  ``__init__`` of database class

## Key Changes
- Moved the initialization table function to  ``__init__`` of database class
- Removed the redundant call from individual read/write methods
