### PR TITLE
fix: remove the `local_files_only` in tokenizer initialization 

### DIFF
--- a/src/model_dataset/loader.py
+++ b/src/model_dataset/loader.py
@@ -71,7 +71,7 @@ class HybirdProductiveLoader:
 
         self.config=config
 
-        self.tokenizer=AutoTokenizer.from_pretrained('BAAI/bge-m3',local_files_only=True)
+        self.tokenizer=AutoTokenizer.from_pretrained('BAAI/bge-m3')
 
 
 


### PR DESCRIPTION
## Overview
Removed ``local_files_only=True`` argument when initializing the tokenizer.

## Key Changes:

- Removed ``local_files_only=True`` when loading the tokenizer 