### PR TITLE
fix: add missing dependency `sentencepiece` and remove `torch` from dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "datasets",                 
     "evaluate",                 
     "peft",                     # Parameter-Efficient Fine-Tuning (LoRA)
+    "sentencepiece",
 
     # --- Data Processing & NLP ---
     "pandas",


### PR DESCRIPTION
## Overview
added missing dependency `sentencepiece` for correct initialization without crashing in `pyproject.toml` .  Removed `torch` from dependence, explicitly tell user to install it from pytorch website for their GPU in `README.md` ( This `README` Change haven't PR, detail in [update-readme Branch](https://github.com/leuas/Vrdndi/tree/docs/update-readme)  )

## Key Changes
- Added missing dependency `sentencepiece`  
- Removed `torch` from dependency. 