### PR TITLE
build: add `aiosqlite` to fix import error from `aw_client`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "mlflow",                   # May switch to mlflow in future 
     "aw-client",                # ActivityWatcher Client 
     "persist-queue[extra]",     # aw_client's dependency
+    "aiosqlite",
     "python-dotenv",            
     "torchmetrics",             # Calculate the metrics
 


### PR DESCRIPTION
## Overview
Added `aiosqlite` to fix the error `No module named 'aiosqlite'` from `aw_client`

## Key Changes
- Added `aiosqlite` to `pyproject.toml`
